### PR TITLE
fix: keep a finger *on* it

### DIFF
--- a/index.pmd
+++ b/index.pmd
@@ -33,7 +33,7 @@ We have created several writeups for this course:
 - [Buses (and networks)](readings/bus.html)
 - [Networking Protocols](readings/protocols.html)
 - [Cryptographic protocols](readings/sec.html)
-- [Caches -- Keep a finger in it](readings/cache.html)
+- [Caches -- Keep a finger on it](readings/cache.html)
 - [Processes and threads](readings/thread.html)
 - [Synchronization primitives](readings/sync.html)
 - [Using POSIX Threads](readings/pthreads.html)

--- a/readings/cache.pmd
+++ b/readings/cache.pmd
@@ -1,5 +1,5 @@
 ---
-title: Caches -- Keep a finger in it
+title: Caches -- Keep a finger on it
 author: Luther Tychnoviech, with modifications by Charles Reiss
 ...
 


### PR DESCRIPTION
Not trying to be overly pedantic, but the reference is "on" it, rather than "in" it. "In it" just sounds off in my opinion...

[Idiom Reference](https://dictionary.cambridge.org/us/dictionary/english/put-finger-on)

<img width="458" alt="Screenshot 2024-04-03 at 9 52 36 AM" src="https://github.com/charlesreiss/cs3130-website/assets/27795014/19f4b911-5fd6-48cf-bc5a-680ad1f63730">
